### PR TITLE
imprv: Replacing URLs in slack

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -63,7 +63,7 @@
             </a>
           </div>
           <div>
-            <a href="https://wsgrowi.slack.com" target="_blank" class="btn btn-hexagon btn-navy text-white fs-6 rounded-0 py-2">
+            <a href="https://communityinviter.com/apps/wsgrowi/invite" target="_blank" class="btn btn-hexagon btn-navy text-white fs-6 rounded-0 py-2">
               <span class="mx-5 d-inline-block"><i class="fab fa-slack me-2"></i>Slack</span>
             </a>
           </div>


### PR DESCRIPTION
## Task
[#130976](https://redmine.weseek.co.jp/issues/130976) [GROWI.org・GROWI.cloud Help] slackin の URL を communityinviter の URL に置き換える
└ [#130977](https://redmine.weseek.co.jp/issues/130977) org 対応