### PR TITLE
support: Update company information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 WESEEK, Inc.
+Copyright (c) 2024 GROWI, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -38,15 +38,15 @@ module.exports = ctx => ({
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1'}],
     ['meta', { name: 'description', content: 'Team Collaboration Software using markdown'}],
     ['meta', { name: 'keywords', content: 'markdown, wiki, javascript, react, growi, crowi'}],
-    ['meta', { name: 'author', content: 'WESEEK, Inc.'}],
+    ['meta', { name: 'author', content: 'GROWI, Inc.'}],
     // OGP
     ['meta', { property: 'og:title', content: 'OSS開発wikiツールのGROWI | 快適な情報共有を、全ての人へ'}],
-    ['meta', { property: 'og:description', content: 'GROWIはWESEEKが開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'}],
+    ['meta', { property: 'og:description', content: 'GROWIはGROWI, Inc.が開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'}],
     ['meta', { property: 'og:image', content: 'https://growi.org/assets/images/ogp-logo.png'}],
     // Twitter
     ['meta', { name: 'twitter:card', content: 'summary'}],
     ['meta', { name: 'twitter:title', content: 'OSS開発wikiツールのGROWI | 快適な情報共有を、全ての人へ'}],
-    ['meta', { name: 'twitter:description', content: 'GROWIはWESEEKが開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'}],
+    ['meta', { name: 'twitter:description', content: 'GROWIはGROWI, Inc.が開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'}],
     ['meta', { name: 'twitter:image', content: 'https://growi.org/assets/images/ogp-logo.png'}],
     ['link', { href: 'https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css', rel: 'stylesheet'}],
     // Fonts
@@ -60,12 +60,12 @@ module.exports = ctx => ({
     '/en/': {
       lang: 'en-US',
       title: 'OSS wiki tool GROWI | Easy and Smooth Information Sharing For Everyone',
-      description: 'GROWI is open source software developed by WESEEK and released under the MIT license. Installation on docker and on-premise support are also possible. We are also looking for contributors who can help with the development and internship students who want to develop.'
+      description: 'GROWI is open source software developed by GROWI, Inc. and released under the MIT license. Installation on docker and on-premise support are also possible. We are also looking for contributors who can help with the development and internship students who want to develop.'
     },
     '/ja/': {
       lang: 'ja',
       title: 'OSS開発wikiツールのGROWI | 快適な情報共有を、全ての人へ',
-      description: 'GROWIはWESEEKが開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'
+      description: 'GROWIはGROWI, Inc.が開発を行い、MITライセンスで公開しているオープンソースソフトウェアです。 dockerへのインストールやオンプレ対応も可能です。 開発を手伝っていただけるコントリビューター、開発してみたいインターン生も募集しています。'
     }
   },
   themeConfig: {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -51,7 +51,7 @@ module.exports = ctx => ({
     ['link', { href: 'https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css', rel: 'stylesheet'}],
     // Fonts
     ['link', { href: 'https://fonts.googleapis.com/css?family=Lato:300,400,400italic,700', rel: 'stylesheet', type: 'text/css'}],
-    ['link', { href: 'https://use.fontawesome.com/releases/v6.2.0/css/all.css', rel: 'stylesheet'}],
+    ['link', { href: 'https://use.fontawesome.com/releases/v6.5.2/css/all.css', rel: 'stylesheet'}],
     ['link', { href: 'https://cdn.linearicons.com/free/1.0.0/icon-font.min.css', rel: 'stylesheet'}],
     ['link', { href: 'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap', rel: 'stylesheet', type: 'text/css'}],
     ['link', { href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap', rel: 'stylesheet'}],

--- a/docs/.vuepress/public/assets/js/map.js
+++ b/docs/.vuepress/public/assets/js/map.js
@@ -23,7 +23,7 @@ $(function () {
         });
 
         var contentString = '<div class="info-window">' +
-                '<h4>WESEEK, Inc.</h4>' +
+                '<h4>GROWI, Inc.</h4>' +
                 '<div class="info-content">' +
                 '<p>あそびにきてね</p>' +
                 '</div>' +

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -267,7 +267,7 @@
           </div>
           <div class="col-sm-6 col-md-4 mt-4 mt-md-0">
             <div class="widget-title">
-              <h3 class="mb-3">WESEEK,Inc.</h3>
+              <h3 class="mb-3">GROWI, Inc.</h3>
               <h4 class="fs-6 text-white mb-0">CONTACT US</h4>
             </div>
             <ul class="mt-4">
@@ -293,7 +293,7 @@
     <!-- footer social icons right -->
     <footer class="d-flex justify-content-between align-items-center">
         <p class="ms-3">
-          © 2018 GROWI - produced by <a :href="data.links.weseek" target="_blank">WESEEK, Inc.</a>
+          © 2024 GROWI - produced by <a :href="data.links.growi" target="_blank">GROWI, Inc.</a>
         </p>
         <a href="https://github.com/weseek" class="ms-auto me-3" target="_blank"><i class="fab fa-github fs-4"></i></a>
     </footer><!-- / footer social icons right -->

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -38,7 +38,7 @@
             </p>
             <!-- Preventing misalignment of button designs by using the `row` class to create a flex container -->
             <div class="btn-green-bg mt-5 mx-auto order-md-3 row px-0">
-              <a href="https://hub.docker.com/r/weseek/growi/" class="btn-green-line fw-bold d-inline-block" target="_blank">
+              <a href="https://hub.docker.com/r/growilabs/growi/" class="btn-green-line fw-bold d-inline-block" target="_blank">
                 <i class="fab fa-docker me-2"></i><span class="btn-text">Dockerhub</span>
               </a>
             </div>
@@ -58,7 +58,7 @@
         </p>
         <div class="d-md-flex justify-content-center">
           <div>
-            <a href="https://github.com/weseek/growi/" target="_blank" class="btn btn-hexagon btn-navy text-white fs-6 rounded-0 py-2">
+            <a href="https://github.com/growilabs/growi/" target="_blank" class="btn btn-hexagon btn-navy text-white fs-6 rounded-0 py-2">
               <span class="mx-5 d-inline-block"><i class="fab fa-github me-2"></i>Github</span>
             </a>
           </div>
@@ -257,11 +257,10 @@
             </div>
             <ul>
               <li><a href="https://growi.cloud/" target="_blank">GROWI.cloud</a></li>
-              <li><a href="https://github.com/weseek/growi" target="_blank"><i class="fab fa-github me-1"></i> weseek/growi</a></li>
-              <li><a href="https://github.com/weseek/growi-docker-compose" target="_blank"><i class="fab fa-github me-1"></i> weseek/growi-docker-compose</a></li>
-              <li><a href="https://hub.docker.com/r/weseek/growi/" target="_blank"><i class="fab fa-docker me-1"></i>Docker Hub</a></li>
+              <li><a href="https://github.com/growilabs/growi" target="_blank"><i class="fab fa-github me-1"></i> growilabs/growi</a></li>
+              <li><a href="https://github.com/growilabs/growi-docker-compose" target="_blank"><i class="fab fa-github me-1"></i> growilabs/growi-docker-compose</a></li>
+              <li><a href="https://hub.docker.com/r/growilabs/growi/" target="_blank"><i class="fab fa-docker me-1"></i>Docker Hub</a></li>
               <li><a href="https://demo.growi.org" target="_blank">demo.growi.org</a></li>
-              <li><a href="https://weseek.co.jp/tech/category/growi/" target="_blank">Tech Blog</a></li>
             </ul>
             <p></p>
           </div>
@@ -295,7 +294,7 @@
         <p class="ms-3">
           © 2024 GROWI - produced by <a :href="data.links.growi" target="_blank">GROWI, Inc.</a>
         </p>
-        <a href="https://github.com/weseek" class="ms-auto me-3" target="_blank"><i class="fab fa-github fs-4"></i></a>
+        <a href="https://github.com/growilabs" class="ms-auto me-3" target="_blank"><i class="fab fa-github fs-4"></i></a>
     </footer><!-- / footer social icons right -->
 
     <!-- javascript -->

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -294,7 +294,10 @@
         <p class="ms-3">
           © 2024 GROWI - produced by <a :href="data.links.growi" target="_blank">GROWI, Inc.</a>
         </p>
-        <a href="https://github.com/growilabs" class="ms-auto me-3" target="_blank"><i class="fab fa-github fs-4"></i></a>
+        <div class="d-flex">
+          <a href="https://github.com/growilabs" class="ms-auto me-3" target="_blank"><i class="fab fa-github fs-4"></i></a>
+          <a href="https://x.com/GrowiDev" class="ms-auto me-3" target="_blank"><i class="fab fa-x-twitter fs-4"></i></a>
+        </div>
     </footer><!-- / footer social icons right -->
 
     <!-- javascript -->

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -19,7 +19,7 @@
       />
     </div>
     <div class="nav-item">
-      <a href="https://github.com/weseek/growi/" target="_blank">
+      <a href="https://github.com/growilabs" target="_blank">
         <i class="fab fa-lg fa-github"></i><a class="d-md-none ms-2">GitHub</a>
       </a>
       <a :href="data.links.admin_guide" target="_blank" class="btn btn-bg-green-gradient text-white fw-bold ms-4 mt-5 mt-md-0 rounded-1">

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -90,7 +90,7 @@ $navbar-vertical-padding = 0.7rem
 $navbar-horizontal-padding = 1.5rem
 
 .navbar
-  // WESEEK Custom
+  // GROWI Custom
   padding $navbar-vertical-padding $navbar-horizontal-padding
   line-height $navbarHeight - 1.4rem
   box-shadow 0px 0px 3px #808080

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -79,7 +79,7 @@ body
 
 a
   font-weight 500
-  // WESEEK Custom
+  // GROWI Custom
   color #185FA5
   text-decoration none
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -16,11 +16,11 @@ heroButtons:
 links:
   admin_guide: https://docs.growi.org/en/admin-guide/
   docs: https://docs.growi.org/en/
-  weseek: https://weseek.co.jp/en/
+  growi: https://growi.co.jp/
 sections:
   introduction:
     title: Open Source GROWI
-    text: GROWI.cloud is open software developed by WESEEK, Inc. <br class="d-none d-md-block" /> And released under MIT license.
+    text: GROWI.cloud is open software developed by GROWI, Inc. <br class="d-none d-md-block" /> And released under MIT license.
   community:
     title: Community-support
     text: We are accepting questions, request and report of bug on our GItHub or Slack.
@@ -40,10 +40,10 @@ sections:
     button_text: Here is more details
   joinus:
     title: JOIN US
-    descriptions: GROWI is open source software developed by <a href="https://weseek.co.jp/en" target="_blank">WESEEK, Inc</a> . and released under the MIT license. We are looking for contributors who can help with development and interns who want to develop. <br/> First join Slack and feel free to talk to the WESEEK members.
+    descriptions: GROWI is open source software developed by <a href="https://growi.co.jp" target="_blank">GROWI, Inc</a> . and released under the MIT license. We are looking for contributors who can help with development and interns who want to develop. <br/> First join Slack and feel free to talk to the GROWI members.
   contact_us:
     address: Takadanobaba Access 10F, 2-20-15 Nishiwaseda, <br /> Shinjuku-ku, Tokyo, Japan
-    email: info@weseek.co.jp
+    email: contact@growi.co.jp
 button:
   start: Starting GROWI
 features:

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -16,11 +16,11 @@ heroButtons:
 links:
   admin_guide: https://docs.growi.org/ja/admin-guide/
   docs: https://docs.growi.org/ja/
-  weseek: https://weseek.co.jp/ja/
+  growi: https://growi.co.jp/
 sections:
   introduction:
     title: オープンソース GROWI
-    text: GROWI は、WESEEK, Inc. が開発を行い、<br class="d-none d-md-block" /> MITライセンスで公開しているオープンソースソフトウェアです。 <br class="d-none d-md-block" /> ユーザーの方も加わった開発が日々活発に行われています。
+    text: GROWI は、GROWI, Inc. が開発を行い、<br class="d-none d-md-block" /> MITライセンスで公開しているオープンソースソフトウェアです。 <br class="d-none d-md-block" /> ユーザーの方も加わった開発が日々活発に行われています。
   community:
     title: コミュニティ・サポート
     text: GROWIに関する質問・要望・バグの報告は、 <br /> GitHubまたはSlackにて受け付けております。
@@ -40,13 +40,13 @@ sections:
     button_text: 詳細はこちら
   joinus:
     title: JOIN US
-    descriptions: GROWI の開発を手伝っていただけるコントリビューター、開発してみたいインターン生を募集しています。 <br /> まずは Slack に参加し、気軽にWESEEKメンバーに声をかけてください！
+    descriptions: GROWI の開発を手伝っていただけるコントリビューター、開発してみたいインターン生を募集しています。 <br /> まずは Slack に参加し、気軽にGROWIメンバーに声をかけてください！
   contact_us:
     address: 東京都新宿区西早稲田2-20-15 <br /> 高田馬場アクセス10F
     tel:
       text: 03-6233-9447
       link: 0362339447
-    email: info@weseek.co.jp
+    email: contact@growi.co.jp
 button:
   start: GROWIを始める
 features:


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/145744
https://redmine.weseek.co.jp/issues/145745

# Summary
- WESEEK に関する記述を GROWI( ,Inc.)に置き換え
  - WESEEK, Inc. => GROWI, Inc.
  - MIT License
    - `Copyright (c) 2018 WESEEK, Inc.` => `Copyright (c) 2024 GROWI, Inc.` 
- アドレスやソーシャルアカウントのリンクおよび記述を置き換え
  - Contact のemail
  - GitHub Docker Hub の組織名 `weseek/growi` => `growilabs/growi`
- フッター
  - コーポレートサイトへのリンクを変更
  - Tech Blog のリンクを削除
  - Xのリンクを追加
    - それに伴い Fontawesome を最新版にアップデート

# ScreenShot
<img width="1320" alt="image" src="https://github.com/weseek/growi-org/assets/113958844/b4434479-b304-4207-ac4c-b6290519eba5">
